### PR TITLE
test: add more tests and migrate to vitest testdirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ dist
 !.env.example
 
 .vite-inspect
+.vitest-testdirs

--- a/package.json
+++ b/package.json
@@ -215,6 +215,7 @@
     "vite": "^6.0.1",
     "vite-plugin-inspect": "^0.10.1",
     "vitest": "^2.1.6",
+    "vitest-testdirs": "^2.1.1",
     "webpack": "^5.96.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,9 @@ importers:
       vitest:
         specifier: ^2.1.6
         version: 2.1.8(@types/node@22.10.10)(terser@5.37.0)
+      vitest-testdirs:
+        specifier: ^2.1.1
+        version: 2.1.1(vitest@2.1.8(@types/node@22.10.10)(terser@5.37.0))
       webpack:
         specifier: ^5.96.1
         version: 5.97.1(esbuild@0.24.2)
@@ -5870,6 +5873,10 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  testdirs@0.1.4:
+    resolution: {integrity: sha512-6ITYziGX1OmfR2HGJgjFwxnKIWdytUuVZV3JwkCal7m2v9kw+r+CZcwjIzjn5Q8Bxdm60a3L3tLDhUOuEwklsQ==}
+    engines: {node: '>=20'}
+
   text-decoder@1.2.1:
     resolution: {integrity: sha512-x9v3H/lTKIJKQQe7RPQkLfKAnc9lUTkWDypIQgTzPJAq+5/GCDHonmshfvlsNSj58yyshbIJJDLmU15qNERrXQ==}
 
@@ -6419,6 +6426,12 @@ packages:
     peerDependenciesMeta:
       vite:
         optional: true
+
+  vitest-testdirs@2.1.1:
+    resolution: {integrity: sha512-1bVjra7vT07fFasVYmpWYBYvvGBogrvjBOBk3UVhCD4ESwhU+CcLBEnpo21jBDgM1KWvWQsg3HZgerMnnBDcsQ==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      vitest: '>=2.0.5 <4.0.0'
 
   vitest@2.1.8:
     resolution: {integrity: sha512-1vBKTZskHw/aosXqQUlVWWlGUxSJR8YtiyZDJAFeW2kPAeX6S3Sool0mjspO+kXLuxVWlEDDowBAeqeAQefqLQ==}
@@ -13515,6 +13528,8 @@ snapshots:
       commander: 2.20.3
       source-map-support: 0.5.21
 
+  testdirs@0.1.4: {}
+
   text-decoder@1.2.1: {}
 
   thenify-all@1.6.0:
@@ -14109,6 +14124,11 @@ snapshots:
   vitefu@1.0.4(vite@5.4.14(@types/node@22.10.10)(terser@5.37.0)):
     optionalDependencies:
       vite: 5.4.14(@types/node@22.10.10)(terser@5.37.0)
+
+  vitest-testdirs@2.1.1(vitest@2.1.8(@types/node@22.10.10)(terser@5.37.0)):
+    dependencies:
+      testdirs: 0.1.4
+      vitest: 2.1.8(@types/node@22.10.10)(terser@5.37.0)
 
   vitest@2.1.8(@types/node@22.10.10)(terser@5.37.0):
     dependencies:

--- a/test/__snapshots__/vite.test.ts.snap
+++ b/test/__snapshots__/vite.test.ts.snap
@@ -1,0 +1,126 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`handle multi document 1`] = `
+"var data = [
+  {
+    "apiVersion": "batch/v1",
+    "kind": "CronJob",
+    "metadata": {
+      "name": "first-cronjob",
+      "namespace": "default"
+    },
+    "spec": {
+      "schedule": "*/10 * * * *",
+      "concurrencyPolicy": "Forbid",
+      "successfulJobsHistoryLimit": 3,
+      "failedJobsHistoryLimit": 1,
+      "jobTemplate": {
+        "spec": {
+          "template": {
+            "spec": {
+              "containers": [
+                {
+                  "name": "first-job",
+                  "image": "busybox:latest",
+                  "command": [
+                    "/bin/sh",
+                    "-c",
+                    'echo "First job running"; date'
+                  ]
+                }
+              ],
+              "restartPolicy": "OnFailure"
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "apiVersion": "batch/v1",
+    "kind": "CronJob",
+    "metadata": {
+      "name": "second-cronjob",
+      "namespace": "default"
+    },
+    "spec": {
+      "schedule": "0 0 * * *",
+      "concurrencyPolicy": "Forbid",
+      "successfulJobsHistoryLimit": 3,
+      "failedJobsHistoryLimit": 1,
+      "jobTemplate": {
+        "spec": {
+          "template": {
+            "spec": {
+              "containers": [
+                {
+                  "name": "second-job",
+                  "image": "busybox:latest",
+                  "command": [
+                    "/bin/sh",
+                    "-c",
+                    'echo "Second job running"; date'
+                  ]
+                }
+              ],
+              "restartPolicy": "OnFailure"
+            }
+          }
+        }
+      }
+    }
+  }
+];
+console.log(data);
+"
+`;
+
+exports[`handle transforms 1`] = `
+"var data = {
+  "this": "transformed"
+};
+console.log(data);
+"
+`;
+
+exports[`handles yaml > expect yaml import to be a json object 1`] = `
+"var data = {
+  "pluginDir": "./plugins",
+  "web": {
+    "enabled": true
+  },
+  "logging": {
+    "type": "stdout",
+    "level": "info"
+  }
+};
+console.log(data);
+"
+`;
+
+exports[`handles yaml > expect yaml import to be a string 1`] = `
+"const config = "pluginDir: ./plugins\\n\\nweb:\\n  enabled: true\\n\\nlogging:\\n  type: stdout\\n  level: info\\n";
+console.log(config);
+"
+`;
+
+exports[`handles yml > expect yml import to be a json object 1`] = `
+"var data = {
+  "pluginDir": "./plugins",
+  "web": {
+    "enabled": true
+  },
+  "logging": {
+    "type": "stdout",
+    "level": "info"
+  }
+};
+console.log(data);
+"
+`;
+
+exports[`handles yml > expect yml import to be a string 1`] = `
+"const config = "pluginDir: ./plugins\\n\\nweb:\\n  enabled: true\\n\\nlogging:\\n  type: stdout\\n  level: info\\n";
+console.log(config);
+"
+`;

--- a/test/esbuild.test.ts
+++ b/test/esbuild.test.ts
@@ -1,13 +1,19 @@
+import { join } from "node:path";
 import { build } from "esbuild";
 import { describe, expect, it } from "vitest";
+import { testdir } from "vitest-testdirs";
 import YAMLPlugin from "../src/esbuild";
 import { removeComments } from "./utils";
 
 describe("handles yaml", () => {
   it("expect yaml import to be a json object", async () => {
+    const testdirPath = await testdir.from(join(import.meta.dirname, "fixtures/basic/yaml"));
+
+    expect(testdirPath).toBeDefined();
+
     const result = await build({
       entryPoints: [
-        "./test/fixtures/basic/yaml/basic.js",
+        join(testdirPath, "basic.js"),
       ],
       format: "esm",
       write: false,
@@ -22,9 +28,13 @@ describe("handles yaml", () => {
   });
 
   it("expect yaml import to be a string", async () => {
+    const testdirPath = await testdir.from(join(import.meta.dirname, "fixtures/basic/yaml"));
+
+    expect(testdirPath).toBeDefined();
+
     const result = await build({
       entryPoints: [
-        "./test/fixtures/basic/yaml/basic-raw.js",
+        join(testdirPath, "basic-raw.js"),
       ],
       format: "esm",
       write: false,
@@ -41,9 +51,13 @@ describe("handles yaml", () => {
 
 describe("handles yml", () => {
   it("expect yml import to be a json object", async () => {
+    const testdirPath = await testdir.from(join(import.meta.dirname, "fixtures/basic/yml"));
+
+    expect(testdirPath).toBeDefined();
+
     const result = await build({
       entryPoints: [
-        "./test/fixtures/basic/yml/basic.js",
+        join(testdirPath, "basic.js"),
       ],
       format: "esm",
       write: false,
@@ -58,9 +72,13 @@ describe("handles yml", () => {
   });
 
   it("expect yml import to be a string", async () => {
+    const testdirPath = await testdir.from(join(import.meta.dirname, "fixtures/basic/yml"));
+
+    expect(testdirPath).toBeDefined();
+
     const result = await build({
       entryPoints: [
-        "./test/fixtures/basic/yml/basic-raw.js",
+        join(testdirPath, "basic-raw.js"),
       ],
       format: "esm",
       write: false,
@@ -76,9 +94,13 @@ describe("handles yml", () => {
 });
 
 it("handle multi document", async () => {
+  const testdirPath = await testdir.from(join(import.meta.dirname, "fixtures/multi"));
+
+  expect(testdirPath).toBeDefined();
+
   const result = await build({
     entryPoints: [
-      "./test/fixtures/multi/multi.js",
+      join(testdirPath, "multi.js"),
     ],
     format: "esm",
     write: false,
@@ -95,9 +117,13 @@ it("handle multi document", async () => {
 });
 
 it("handle transforms", async () => {
+  const testdirPath = await testdir.from(join(import.meta.dirname, "fixtures/transform"));
+
+  expect(testdirPath).toBeDefined();
+
   const result = await build({
     entryPoints: [
-      "./test/fixtures/transform/transform.js",
+      join(testdirPath, "transform.js"),
     ],
     format: "esm",
     write: false,

--- a/test/rolldown.test.ts
+++ b/test/rolldown.test.ts
@@ -1,12 +1,18 @@
+import { join } from "node:path";
 import { rolldown } from "rolldown";
 import { describe, expect, it } from "vitest";
+import { testdir } from "vitest-testdirs";
 import YAMLPlugin from "../src/rolldown";
 import { removeComments } from "./utils";
 
 describe("handles yaml", () => {
   it("expect yaml import to be a json object", async () => {
+    const testdirPath = await testdir.from(join(import.meta.dirname, "fixtures/basic/yaml"));
+
+    expect(testdirPath).toBeDefined();
+
     const bundle = await rolldown({
-      input: "./test/fixtures/basic/yaml/basic.js",
+      input: join(testdirPath, "basic.js"),
       plugins: [
         YAMLPlugin(),
       ],
@@ -20,8 +26,12 @@ describe("handles yaml", () => {
   });
 
   it("expect yaml import to be a string", async () => {
+    const testdirPath = await testdir.from(join(import.meta.dirname, "fixtures/basic/yaml"));
+
+    expect(testdirPath).toBeDefined();
+
     const bundle = await rolldown({
-      input: "./test/fixtures/basic/yaml/basic-raw.js",
+      input: join(testdirPath, "basic-raw.js"),
       plugins: [
         YAMLPlugin(),
       ],
@@ -37,8 +47,12 @@ describe("handles yaml", () => {
 
 describe("handle yml", () => {
   it("expect yml import to be a json object", async () => {
+    const testdirPath = await testdir.from(join(import.meta.dirname, "fixtures/basic/yml"));
+
+    expect(testdirPath).toBeDefined();
+
     const bundle = await rolldown({
-      input: "./test/fixtures/basic/yml/basic.js",
+      input: join(testdirPath, "basic.js"),
       plugins: [
         YAMLPlugin(),
       ],
@@ -52,8 +66,12 @@ describe("handle yml", () => {
   });
 
   it("expect yml import to be a string", async () => {
+    const testdirPath = await testdir.from(join(import.meta.dirname, "fixtures/basic/yml"));
+
+    expect(testdirPath).toBeDefined();
+
     const bundle = await rolldown({
-      input: "./test/fixtures/basic/yml/basic-raw.js",
+      input: join(testdirPath, "basic-raw.js"),
       plugins: [
         YAMLPlugin(),
       ],
@@ -68,8 +86,12 @@ describe("handle yml", () => {
 });
 
 it("handle multi document", async () => {
+  const testdirPath = await testdir.from(join(import.meta.dirname, "fixtures/multi"));
+
+  expect(testdirPath).toBeDefined();
+
   const bundle = await rolldown({
-    input: "./test/fixtures/multi/multi.js",
+    input: join(testdirPath, "multi.js"),
     plugins: [
       YAMLPlugin({
         type: "multi",
@@ -85,8 +107,12 @@ it("handle multi document", async () => {
 });
 
 it("handle transforms", async () => {
+  const testdirPath = await testdir.from(join(import.meta.dirname, "fixtures/transform"));
+
+  expect(testdirPath).toBeDefined();
+
   const bundle = await rolldown({
-    input: "./test/fixtures/transform/transform.js",
+    input: join(testdirPath, "transform.js"),
     plugins: [
       YAMLPlugin({
         transform(data) {

--- a/test/rollup.test.ts
+++ b/test/rollup.test.ts
@@ -1,12 +1,18 @@
+import { join } from "node:path";
 import { rollup } from "rollup";
 import { describe, expect, it } from "vitest";
+import { testdir } from "vitest-testdirs";
 import YAMLPlugin from "../src/rollup";
 import { removeComments } from "./utils";
 
 describe("handles yaml", () => {
   it("expect yaml import to be a json object", async () => {
+    const testdirPath = await testdir.from(join(import.meta.dirname, "fixtures/basic/yaml"));
+
+    expect(testdirPath).toBeDefined();
+
     const bundle = await rollup({
-      input: "./test/fixtures/basic/yaml/basic.js",
+      input: join(testdirPath, "basic.js"),
       plugins: [
         YAMLPlugin(),
       ],
@@ -20,8 +26,12 @@ describe("handles yaml", () => {
   });
 
   it("expect yaml import to be a string", async () => {
+    const testdirPath = await testdir.from(join(import.meta.dirname, "fixtures/basic/yaml"));
+
+    expect(testdirPath).toBeDefined();
+
     const bundle = await rollup({
-      input: "./test/fixtures/basic/yaml/basic-raw.js",
+      input: join(testdirPath, "basic-raw.js"),
       plugins: [
         YAMLPlugin(),
       ],
@@ -37,8 +47,12 @@ describe("handles yaml", () => {
 
 describe("handle yml", () => {
   it("expect yml import to be a json object", async () => {
+    const testdirPath = await testdir.from(join(import.meta.dirname, "fixtures/basic/yml"));
+
+    expect(testdirPath).toBeDefined();
+
     const bundle = await rollup({
-      input: "./test/fixtures/basic/yml/basic.js",
+      input: join(testdirPath, "basic.js"),
       plugins: [
         YAMLPlugin(),
       ],
@@ -52,8 +66,12 @@ describe("handle yml", () => {
   });
 
   it("expect yml import to be a string", async () => {
+    const testdirPath = await testdir.from(join(import.meta.dirname, "fixtures/basic/yml"));
+
+    expect(testdirPath).toBeDefined();
+
     const bundle = await rollup({
-      input: "./test/fixtures/basic/yml/basic-raw.js",
+      input: join(testdirPath, "basic-raw.js"),
       plugins: [
         YAMLPlugin(),
       ],
@@ -68,8 +86,12 @@ describe("handle yml", () => {
 });
 
 it("handle multi document", async () => {
+  const testdirPath = await testdir.from(join(import.meta.dirname, "fixtures/multi"));
+
+  expect(testdirPath).toBeDefined();
+
   const bundle = await rollup({
-    input: "./test/fixtures/multi/multi.js",
+    input: join(testdirPath, "multi.js"),
     plugins: [
       YAMLPlugin({
         type: "multi",
@@ -85,8 +107,12 @@ it("handle multi document", async () => {
 });
 
 it("handle transforms", async () => {
+  const testdirPath = await testdir.from(join(import.meta.dirname, "fixtures/transform"));
+
+  expect(testdirPath).toBeDefined();
+
   const bundle = await rollup({
-    input: "./test/fixtures/transform/transform.js",
+    input: join(testdirPath, "transform.js"),
     plugins: [
       YAMLPlugin({
         transform(data) {

--- a/test/rspack.test.ts
+++ b/test/rspack.test.ts
@@ -1,23 +1,21 @@
 import type { Configuration, Stats } from "@rspack/core";
 import { readFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import path from "node:path";
+import path, { join } from "node:path";
 import { rspack as createRspack } from "@rspack/core";
 import { describe, expect, it } from "vitest";
-
+import { testdir } from "vitest-testdirs";
 import YAMLPlugin from "../src/rspack";
 import { removeComments } from "./utils";
 
-const dir = path.join(tmpdir(), "unplugin-yaml-tests");
-async function rspack(config: Configuration): Promise<Stats | undefined> {
+async function rspack(config: Configuration, testdirPath: string): Promise<Stats | undefined> {
   return new Promise((resolve, reject) => {
     const compiler = createRspack({
       optimization: {
         minimize: true,
       },
       output: {
-        path: dir,
-        filename: `${Date.now()}-bundle.js`,
+        path: join(testdirPath, "dist"),
+        filename: "bundle.js",
       },
       mode: "production",
       ...config,
@@ -43,35 +41,43 @@ async function rspack(config: Configuration): Promise<Stats | undefined> {
 
 describe("handles yaml", () => {
   it("expect yaml import to be a json object", async () => {
+    const testdirPath = await testdir.from(join(import.meta.dirname, "fixtures/basic/yaml"));
+
+    expect(testdirPath).toBeDefined();
+
     const result = await rspack({
-      entry: "./test/fixtures/basic/yaml/basic.js",
+      entry: join(testdirPath, "basic.js"),
       plugins: [
         YAMLPlugin(),
       ],
-    });
+    }, testdirPath);
 
     const json = result?.toJson();
     expect(json).toBeDefined();
 
     const file = json!.assetsByChunkName!.main;
-    const content = await readFile(path.join(dir, file![0]!), "utf-8");
+    const content = await readFile(path.join(testdirPath, "dist", file![0]!), "utf-8");
 
     expect(removeComments(content)).toMatchSnapshot();
   });
 
   it("expect yaml import to be a string", async () => {
+    const testdirPath = await testdir.from(join(import.meta.dirname, "fixtures/basic/yaml"));
+
+    expect(testdirPath).toBeDefined();
+
     const result = await rspack({
-      entry: "./test/fixtures/basic/yaml/basic-raw.js",
+      entry: join(testdirPath, "basic-raw.js"),
       plugins: [
         YAMLPlugin(),
       ],
-    });
+    }, testdirPath);
 
     const json = result?.toJson();
     expect(json).toBeDefined();
 
     const file = json!.assetsByChunkName!.main;
-    const content = await readFile(path.join(dir, file![0]!), "utf-8");
+    const content = await readFile(path.join(testdirPath, "dist", file![0]!), "utf-8");
 
     expect(removeComments(content)).toMatchSnapshot();
   });
@@ -79,62 +85,78 @@ describe("handles yaml", () => {
 
 describe("handle yml", () => {
   it("expect yml import to be a json object", async () => {
+    const testdirPath = await testdir.from(join(import.meta.dirname, "fixtures/basic/yml"));
+
+    expect(testdirPath).toBeDefined();
+
     const result = await rspack({
-      entry: "./test/fixtures/basic/yml/basic.js",
+      entry: join(testdirPath, "basic.js"),
       plugins: [
         YAMLPlugin(),
       ],
-    });
+    }, testdirPath);
 
     const json = result?.toJson();
     expect(json).toBeDefined();
 
     const file = json!.assetsByChunkName!.main;
-    const content = await readFile(path.join(dir, file![0]!), "utf-8");
+    const content = await readFile(path.join(testdirPath, "dist", file![0]!), "utf-8");
 
     expect(removeComments(content)).toMatchSnapshot();
   });
 
   it("expect yml import to be a string", async () => {
+    const testdirPath = await testdir.from(join(import.meta.dirname, "fixtures/basic/yml"));
+
+    expect(testdirPath).toBeDefined();
+
     const result = await rspack({
-      entry: "./test/fixtures/basic/yml/basic-raw.js",
+      entry: join(testdirPath, "basic-raw.js"),
       plugins: [
         YAMLPlugin(),
       ],
-    });
+    }, testdirPath);
 
     const json = result?.toJson();
     expect(json).toBeDefined();
 
     const file = json!.assetsByChunkName!.main;
-    const content = await readFile(path.join(dir, file![0]!), "utf-8");
+    const content = await readFile(path.join(testdirPath, "dist", file![0]!), "utf-8");
 
     expect(removeComments(content)).toMatchSnapshot();
   });
 });
 
 it("handle multi document", async () => {
+  const testdirPath = await testdir.from(join(import.meta.dirname, "fixtures/multi"));
+
+  expect(testdirPath).toBeDefined();
+
   const result = await rspack({
-    entry: "./test/fixtures/multi/multi.js",
+    entry: join(testdirPath, "multi.js"),
     plugins: [
       YAMLPlugin({
         type: "multi",
       }),
     ],
-  });
+  }, testdirPath);
 
   const json = result?.toJson();
   expect(json).toBeDefined();
 
   const file = json!.assetsByChunkName!.main;
-  const content = await readFile(path.join(dir, file![0]!), "utf-8");
+  const content = await readFile(path.join(testdirPath, "dist", file![0]!), "utf-8");
 
   expect(removeComments(content)).toMatchSnapshot();
 });
 
 it("handle transforms", async () => {
+  const testdirPath = await testdir.from(join(import.meta.dirname, "fixtures/transform"));
+
+  expect(testdirPath).toBeDefined();
+
   const result = await rspack({
-    entry: "./test/fixtures/transform/transform.js",
+    entry: join(testdirPath, "transform.js"),
     plugins: [
       YAMLPlugin({
         transform(data) {
@@ -146,13 +168,13 @@ it("handle transforms", async () => {
         },
       }),
     ],
-  });
+  }, testdirPath);
 
   const json = result?.toJson();
   expect(json).toBeDefined();
 
   const file = json!.assetsByChunkName!.main;
-  const content = await readFile(path.join(dir, file![0]!), "utf-8");
+  const content = await readFile(path.join(testdirPath, "dist", file![0]!), "utf-8");
 
   expect(removeComments(content)).toMatchSnapshot();
 });

--- a/test/rspack.test.ts
+++ b/test/rspack.test.ts
@@ -1,6 +1,6 @@
 import type { Configuration, Stats } from "@rspack/core";
 import { readFile } from "node:fs/promises";
-import path, { join } from "node:path";
+import { join } from "node:path";
 import { rspack as createRspack } from "@rspack/core";
 import { describe, expect, it } from "vitest";
 import { testdir } from "vitest-testdirs";
@@ -72,7 +72,7 @@ describe("handles yaml", () => {
       ],
     }, testdirPath);
 
-    const content = await readFile(path.join(testdirPath, "dist", file), "utf-8");
+    const content = await readFile(join(testdirPath, "dist", file), "utf-8");
 
     expect(removeComments(content)).toMatchSnapshot();
   });
@@ -89,7 +89,7 @@ describe("handles yaml", () => {
       ],
     }, testdirPath);
 
-    const content = await readFile(path.join(testdirPath, "dist", file), "utf-8");
+    const content = await readFile(join(testdirPath, "dist", file), "utf-8");
 
     expect(removeComments(content)).toMatchSnapshot();
   });
@@ -108,7 +108,7 @@ describe("handle yml", () => {
       ],
     }, testdirPath);
 
-    const content = await readFile(path.join(testdirPath, "dist", file), "utf-8");
+    const content = await readFile(join(testdirPath, "dist", file), "utf-8");
 
     expect(removeComments(content)).toMatchSnapshot();
   });
@@ -125,7 +125,7 @@ describe("handle yml", () => {
       ],
     }, testdirPath);
 
-    const content = await readFile(path.join(testdirPath, "dist", file), "utf-8");
+    const content = await readFile(join(testdirPath, "dist", file), "utf-8");
 
     expect(removeComments(content)).toMatchSnapshot();
   });
@@ -145,7 +145,7 @@ it("handle multi document", async () => {
     ],
   }, testdirPath);
 
-  const content = await readFile(path.join(testdirPath, "dist", file), "utf-8");
+  const content = await readFile(join(testdirPath, "dist", file), "utf-8");
 
   expect(removeComments(content)).toMatchSnapshot();
 });
@@ -170,7 +170,7 @@ it("handle transforms", async () => {
     ],
   }, testdirPath);
 
-  const content = await readFile(path.join(testdirPath, "dist", file), "utf-8");
+  const content = await readFile(join(testdirPath, "dist", file), "utf-8");
 
   expect(removeComments(content)).toMatchSnapshot();
 });

--- a/test/vite.test.ts
+++ b/test/vite.test.ts
@@ -1,0 +1,224 @@
+import { join } from "node:path";
+import { build } from "vite";
+import { describe, expect, it } from "vitest";
+import { fromFileSystem, testdir, type TestdirFromOptions, type TestdirOptions } from "vitest-testdirs";
+import YAMLPlugin from "../src/vite";
+import { removeComments } from "./utils";
+
+describe("handles yaml", () => {
+  it("expect yaml import to be a json object", async () => {
+    const testdirPath = await testdir.from(join(import.meta.dirname, "fixtures/basic/yaml"));
+
+    expect(testdirPath).toBeDefined();
+
+    const result = await build({
+      build: {
+        lib: {
+          entry: join(testdirPath, "basic.js"),
+          formats: ["es"],
+          fileName: "bundle",
+          name: "bundle",
+        },
+        outDir: join(testdirPath, "dist"),
+        minify: false,
+      },
+      plugins: [YAMLPlugin()],
+    });
+
+    if (!Array.isArray(result)) {
+      expect.fail("result is not an array");
+    }
+
+    expect(result).toBeDefined();
+
+    const firstResult = result[0];
+
+    expect(firstResult).toBeDefined();
+    expect(firstResult?.output).toBeDefined();
+    expect(firstResult?.output[0]).toBeDefined();
+    expect(firstResult?.output[0].code).toBeDefined();
+    expect(firstResult?.output[0].code).toMatchSnapshot();
+  });
+
+  it("expect yaml import to be a string", async () => {
+    const testdirPath = await testdir.from(join(import.meta.dirname, "fixtures/basic/yaml"));
+
+    expect(testdirPath).toBeDefined();
+
+    const result = await build({
+      build: {
+        lib: {
+          entry: join(testdirPath, "basic-raw.js"),
+          formats: ["es"],
+          fileName: "bundle",
+          name: "bundle",
+        },
+        outDir: join(testdirPath, "dist"),
+        minify: false,
+      },
+      plugins: [YAMLPlugin()],
+    });
+
+    if (!Array.isArray(result)) {
+      expect.fail("result is not an array");
+    }
+
+    expect(result).toBeDefined();
+
+    const firstResult = result[0];
+
+    expect(firstResult).toBeDefined();
+    expect(firstResult?.output).toBeDefined();
+    expect(firstResult?.output[0]).toBeDefined();
+    expect(firstResult?.output[0].code).toBeDefined();
+    expect(firstResult?.output[0].code).toMatchSnapshot();
+  });
+});
+
+describe("handles yml", () => {
+  it("expect yml import to be a json object", async () => {
+    const testdirPath = await testdir.from(join(import.meta.dirname, "fixtures/basic/yml"));
+
+    expect(testdirPath).toBeDefined();
+
+    const result = await build({
+      build: {
+        lib: {
+          entry: join(testdirPath, "basic.js"),
+          formats: ["es"],
+          fileName: "bundle",
+          name: "bundle",
+        },
+        outDir: join(testdirPath, "dist"),
+        minify: false,
+      },
+      plugins: [YAMLPlugin()],
+    });
+
+    if (!Array.isArray(result)) {
+      expect.fail("result is not an array");
+    }
+
+    expect(result).toBeDefined();
+
+    const firstResult = result[0];
+
+    expect(firstResult).toBeDefined();
+    expect(firstResult?.output).toBeDefined();
+    expect(firstResult?.output[0]).toBeDefined();
+    expect(firstResult?.output[0].code).toBeDefined();
+    expect(firstResult?.output[0].code).toMatchSnapshot();
+  });
+
+  it("expect yml import to be a string", async () => {
+    const testdirPath = await testdir.from(join(import.meta.dirname, "fixtures/basic/yml"));
+
+    expect(testdirPath).toBeDefined();
+
+    const result = await build({
+      build: {
+        lib: {
+          entry: join(testdirPath, "basic-raw.js"),
+          formats: ["es"],
+          fileName: "bundle",
+          name: "bundle",
+        },
+        outDir: join(testdirPath, "dist"),
+        minify: false,
+      },
+      plugins: [YAMLPlugin()],
+    });
+
+    if (!Array.isArray(result)) {
+      expect.fail("result is not an array");
+    }
+
+    expect(result).toBeDefined();
+
+    const firstResult = result[0];
+
+    expect(firstResult).toBeDefined();
+    expect(firstResult?.output).toBeDefined();
+    expect(firstResult?.output[0]).toBeDefined();
+    expect(firstResult?.output[0].code).toBeDefined();
+    expect(firstResult?.output[0].code).toMatchSnapshot();
+  });
+});
+
+it("handle multi document", async () => {
+  const testdirPath = await testdir.from(join(import.meta.dirname, "fixtures/multi"));
+
+  expect(testdirPath).toBeDefined();
+
+  const result = await build({
+    build: {
+      lib: {
+        entry: join(testdirPath, "multi.js"),
+        formats: ["es"],
+        fileName: "bundle",
+        name: "bundle",
+      },
+      outDir: join(testdirPath, "dist"),
+      minify: false,
+    },
+    plugins: [YAMLPlugin({
+      type: "multi",
+    })],
+  });
+
+  if (!Array.isArray(result)) {
+    expect.fail("result is not an array");
+  }
+
+  expect(result).toBeDefined();
+
+  const firstResult = result[0];
+
+  expect(firstResult).toBeDefined();
+  expect(firstResult?.output).toBeDefined();
+  expect(firstResult?.output[0]).toBeDefined();
+  expect(firstResult?.output[0].code).toBeDefined();
+  expect(firstResult?.output[0].code).toMatchSnapshot();
+});
+
+it("handle transforms", async () => {
+  const testdirPath = await testdir.from(join(import.meta.dirname, "fixtures/transform"));
+
+  expect(testdirPath).toBeDefined();
+
+  const result = await build({
+    build: {
+      lib: {
+        entry: join(testdirPath, "transform.js"),
+        formats: ["es"],
+        fileName: "bundle",
+        name: "bundle",
+      },
+      outDir: join(testdirPath, "dist"),
+      minify: false,
+    },
+    plugins: [YAMLPlugin({
+      transform(data) {
+        if (data != null && typeof data === "object" && "this" in data) {
+          return {
+            this: "transformed",
+          };
+        }
+      },
+    })],
+  });
+
+  if (!Array.isArray(result)) {
+    expect.fail("result is not an array");
+  }
+
+  expect(result).toBeDefined();
+
+  const firstResult = result[0];
+
+  expect(firstResult).toBeDefined();
+  expect(firstResult?.output).toBeDefined();
+  expect(firstResult?.output[0]).toBeDefined();
+  expect(firstResult?.output[0].code).toBeDefined();
+  expect(firstResult?.output[0].code).toMatchSnapshot();
+});

--- a/test/vite.test.ts
+++ b/test/vite.test.ts
@@ -1,9 +1,8 @@
 import { join } from "node:path";
 import { build } from "vite";
 import { describe, expect, it } from "vitest";
-import { fromFileSystem, testdir, type TestdirFromOptions, type TestdirOptions } from "vitest-testdirs";
+import { testdir } from "vitest-testdirs";
 import YAMLPlugin from "../src/vite";
-import { removeComments } from "./utils";
 
 describe("handles yaml", () => {
   it("expect yaml import to be a json object", async () => {

--- a/test/webpack.test.ts
+++ b/test/webpack.test.ts
@@ -1,6 +1,6 @@
 import type { Configuration, Stats } from "webpack";
 import { readFile } from "node:fs/promises";
-import path, { join } from "node:path";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { testdir } from "vitest-testdirs";
 import { webpack as createWebpack } from "webpack";
@@ -64,7 +64,7 @@ describe("handles yaml", () => {
       ],
     }, testdirPath);
 
-    const content = await readFile(path.join(testdirPath, "dist", file), "utf-8");
+    const content = await readFile(join(testdirPath, "dist", file), "utf-8");
 
     expect(removeComments(content)).toMatchSnapshot();
   });
@@ -81,7 +81,7 @@ describe("handles yaml", () => {
       ],
     }, testdirPath);
 
-    const content = await readFile(path.join(testdirPath, "dist", file), "utf-8");
+    const content = await readFile(join(testdirPath, "dist", file), "utf-8");
 
     expect(removeComments(content)).toMatchSnapshot();
   });
@@ -100,7 +100,7 @@ describe("handle yml", () => {
       ],
     }, testdirPath);
 
-    const content = await readFile(path.join(testdirPath, "dist", file), "utf-8");
+    const content = await readFile(join(testdirPath, "dist", file), "utf-8");
 
     expect(removeComments(content)).toMatchSnapshot();
   });
@@ -117,7 +117,7 @@ describe("handle yml", () => {
       ],
     }, testdirPath);
 
-    const content = await readFile(path.join(testdirPath, "dist", file), "utf-8");
+    const content = await readFile(join(testdirPath, "dist", file), "utf-8");
 
     expect(removeComments(content)).toMatchSnapshot();
   });
@@ -137,7 +137,7 @@ it("handle multi document", async () => {
     ],
   }, testdirPath);
 
-  const content = await readFile(path.join(testdirPath, "dist", file), "utf-8");
+  const content = await readFile(join(testdirPath, "dist", file), "utf-8");
 
   expect(removeComments(content)).toMatchSnapshot();
 });
@@ -162,7 +162,7 @@ it("handle transforms", async () => {
     ],
   }, testdirPath);
 
-  const content = await readFile(path.join(testdirPath, "dist", file), "utf-8");
+  const content = await readFile(join(testdirPath, "dist", file), "utf-8");
 
   expect(removeComments(content)).toMatchSnapshot();
 });

--- a/test/webpack.test.ts
+++ b/test/webpack.test.ts
@@ -1,23 +1,21 @@
 import type { Configuration, Stats } from "webpack";
 import { readFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import path from "node:path";
+import path, { join } from "node:path";
 import { describe, expect, it } from "vitest";
+import { testdir } from "vitest-testdirs";
 import { webpack as createWebpack } from "webpack";
 import YAMLPlugin from "../src/webpack";
 import { removeComments } from "./utils";
 
-const dir = path.join(tmpdir(), "unplugin-yaml-tests");
-
-async function webpack(config: Configuration): Promise<Stats | undefined> {
+async function webpack(config: Configuration, testdirPath: string): Promise<Stats | undefined> {
   return new Promise((resolve, reject) => {
     const compiler = createWebpack({
       optimization: {
         minimize: true,
       },
       output: {
-        path: dir,
-        filename: `${Date.now()}-bundle.js`,
+        path: join(testdirPath, "dist"),
+        filename: "bundle.js",
       },
       mode: "production",
       ...config,
@@ -35,35 +33,43 @@ async function webpack(config: Configuration): Promise<Stats | undefined> {
 
 describe("handles yaml", () => {
   it("expect yaml import to be a json object", async () => {
+    const testdirPath = await testdir.from(join(import.meta.dirname, "fixtures/basic/yaml"));
+
+    expect(testdirPath).toBeDefined();
+
     const result = await webpack({
-      entry: "./test/fixtures/basic/yaml/basic.js",
+      entry: join(testdirPath, "basic.js"),
       plugins: [
         YAMLPlugin(),
       ],
-    });
+    }, testdirPath);
 
     const json = result?.toJson();
     expect(json).toBeDefined();
 
     const file = json!.assetsByChunkName!.main;
-    const content = await readFile(path.join(dir, file![0]!), "utf-8");
+    const content = await readFile(path.join(testdirPath, "dist", file![0]!), "utf-8");
 
     expect(removeComments(content)).toMatchSnapshot();
   });
 
   it("expect yaml import to be a string", async () => {
+    const testdirPath = await testdir.from(join(import.meta.dirname, "fixtures/basic/yaml"));
+
+    expect(testdirPath).toBeDefined();
+
     const result = await webpack({
-      entry: "./test/fixtures/basic/yaml/basic-raw.js",
+      entry: join(testdirPath, "basic-raw.js"),
       plugins: [
         YAMLPlugin(),
       ],
-    });
+    }, testdirPath);
 
     const json = result?.toJson();
     expect(json).toBeDefined();
 
     const file = json!.assetsByChunkName!.main;
-    const content = await readFile(path.join(dir, file![0]!), "utf-8");
+    const content = await readFile(path.join(testdirPath, "dist", file![0]!), "utf-8");
 
     expect(removeComments(content)).toMatchSnapshot();
   });
@@ -71,62 +77,78 @@ describe("handles yaml", () => {
 
 describe("handle yml", () => {
   it("expect yml import to be a json object", async () => {
+    const testdirPath = await testdir.from(join(import.meta.dirname, "fixtures/basic/yml"));
+
+    expect(testdirPath).toBeDefined();
+
     const result = await webpack({
-      entry: "./test/fixtures/basic/yml/basic.js",
+      entry: join(testdirPath, "basic.js"),
       plugins: [
         YAMLPlugin(),
       ],
-    });
+    }, testdirPath);
 
     const json = result?.toJson();
     expect(json).toBeDefined();
 
     const file = json!.assetsByChunkName!.main;
-    const content = await readFile(path.join(dir, file![0]!), "utf-8");
+    const content = await readFile(path.join(testdirPath, "dist", file![0]!), "utf-8");
 
     expect(removeComments(content)).toMatchSnapshot();
   });
 
   it("expect yml import to be a string", async () => {
+    const testdirPath = await testdir.from(join(import.meta.dirname, "fixtures/basic/yml"));
+
+    expect(testdirPath).toBeDefined();
+
     const result = await webpack({
-      entry: "./test/fixtures/basic/yml/basic-raw.js",
+      entry: join(testdirPath, "basic-raw.js"),
       plugins: [
         YAMLPlugin(),
       ],
-    });
+    }, testdirPath);
 
     const json = result?.toJson();
     expect(json).toBeDefined();
 
     const file = json!.assetsByChunkName!.main;
-    const content = await readFile(path.join(dir, file![0]!), "utf-8");
+    const content = await readFile(path.join(testdirPath, "dist", file![0]!), "utf-8");
 
     expect(removeComments(content)).toMatchSnapshot();
   });
 });
 
 it("handle multi document", async () => {
+  const testdirPath = await testdir.from(join(import.meta.dirname, "fixtures/multi"));
+
+  expect(testdirPath).toBeDefined();
+
   const result = await webpack({
-    entry: "./test/fixtures/multi/multi.js",
+    entry: join(testdirPath, "multi.js"),
     plugins: [
       YAMLPlugin({
         type: "multi",
       }),
     ],
-  });
+  }, testdirPath);
 
   const json = result?.toJson();
   expect(json).toBeDefined();
 
   const file = json!.assetsByChunkName!.main;
-  const content = await readFile(path.join(dir, file![0]!), "utf-8");
+  const content = await readFile(path.join(testdirPath, "dist", file![0]!), "utf-8");
 
   expect(removeComments(content)).toMatchSnapshot();
 });
 
 it("handle transforms", async () => {
+  const testdirPath = await testdir.from(join(import.meta.dirname, "fixtures/transform"));
+
+  expect(testdirPath).toBeDefined();
+
   const result = await webpack({
-    entry: "./test/fixtures/transform/transform.js",
+    entry: join(testdirPath, "transform.js"),
     plugins: [
       YAMLPlugin({
         transform(data) {
@@ -138,13 +160,13 @@ it("handle transforms", async () => {
         },
       }),
     ],
-  });
+  }, testdirPath);
 
   const json = result?.toJson();
   expect(json).toBeDefined();
 
   const file = json!.assetsByChunkName!.main;
-  const content = await readFile(path.join(dir, file![0]!), "utf-8");
+  const content = await readFile(path.join(testdirPath, "dist", file![0]!), "utf-8");
 
   expect(removeComments(content)).toMatchSnapshot();
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added support for dynamically generating test directory paths using `vitest-testdirs`

- **Chores**
  - Added `vitest-testdirs` as a development dependency

- **Tests**
  - Improved test fixture path handling across multiple test files
  - Enhanced test robustness by replacing hardcoded paths with dynamically generated paths
  - Introduced new tests for handling YAML and YML file imports with the Vite build tool
<!-- end of auto-generated comment: release notes by coderabbit.ai -->