### PR TITLE
chore: add package homepage metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "yaml"
   ],
   "bugs": "https://github.com/luxass/unplugin-yaml/issues",
+  "homepage": "https://github.com/luxass/unplugin-yaml#readme",
   "license": "MIT",
   "author": {
     "name": "Lucas Nørgård",


### PR DESCRIPTION
## Summary

Adds package-specific npm homepage metadata for `unplugin-yaml`.

The published `unplugin-yaml@4.2.1` package already exposes public repository and issue metadata, but `homepage` is absent. This patch points npm users directly to the public README:

`https://github.com/luxass/unplugin-yaml#readme`

No runtime code, dependencies, exports, lockfiles, or package version fields changed.

## Validation

```text
node package metadata assertion: passed
npm pack --dry-run --ignore-scripts --json .: passed
git diff --check: passed
```

## Scope

- `package.json` only
- Metadata-only change
- Public MIT repository
